### PR TITLE
AIR-8 : do not cancel stackwalk when symbols not found.

### DIFF
--- a/src/processor/stack_frame_symbolizer.cc
+++ b/src/processor/stack_frame_symbolizer.cc
@@ -75,7 +75,9 @@ StackFrameSymbolizer::SymbolizerResult StackFrameSymbolizer::FillSourceLineInfo(
   // If module is known to have missing symbol file, return.
   if (no_symbol_modules_.find(module->code_file()) !=
       no_symbol_modules_.end()) {
-    return kError;
+    //BZ: Previously, this would generate an error, which would cancel
+    // the remainder of the stackwalk.
+    return kNoError;
   }
 
   // If module is already loaded, go ahead to fill source line info and return.
@@ -112,9 +114,11 @@ StackFrameSymbolizer::SymbolizerResult StackFrameSymbolizer::FillSourceLineInfo(
         return resolver_->IsModuleCorrupt(frame->module) ?
             kWarningCorruptSymbols : kNoError;
       } else {
+        //BZ: Previously, this would generate an error, which would cancel
+        // the remainder of the stackwalk.
         BPLOG(ERROR) << "Failed to load symbol file in resolver.";
         no_symbol_modules_.insert(module->code_file());
-        return kError;
+        return kNoError;
       }
     }
 


### PR DESCRIPTION
AIR-8 : do not cancel stackwalk when symbols not found.