### PR TITLE
Fix UBSAN reported access within misaligned addresses

### DIFF
--- a/src/client/linux/minidump_writer/directory_reader.h
+++ b/src/client/linux/minidump_writer/directory_reader.h
@@ -95,9 +95,10 @@ class DirectoryReader {
 
  private:
   const int fd_;
-  bool hit_eof_;
   unsigned buf_used_;
-  uint8_t buf_[sizeof(struct kernel_dirent) + NAME_MAX + 1];
+  alignas(struct kernel_dirent)
+      uint8_t buf_[sizeof(struct kernel_dirent) + NAME_MAX + 1];
+  bool hit_eof_;
 };
 
 }  // namespace google_breakpad

--- a/src/client/linux/minidump_writer/minidump_writer.cc
+++ b/src/client/linux/minidump_writer/minidump_writer.cc
@@ -772,9 +772,11 @@ class MinidumpWriter {
     const std::vector<uint64_t> crash_exception_info =
         dumper_->crash_exception_info();
     stream->exception_record.number_parameters = crash_exception_info.size();
-    memcpy(stream->exception_record.exception_information,
-           crash_exception_info.data(),
-           sizeof(uint64_t) * crash_exception_info.size());
+    if (!crash_exception_info.empty()) {
+      memcpy(stream->exception_record.exception_information,
+             crash_exception_info.data(),
+             sizeof(uint64_t) * crash_exception_info.size());
+    }
     stream->thread_context = crashing_thread_context_;
 
     return true;

--- a/src/common/memory_allocator.h
+++ b/src/common/memory_allocator.h
@@ -76,7 +76,8 @@ class PageAllocator {
 
     if (current_page_ && page_size_ - page_offset_ >= bytes) {
       uint8_t* const ret = current_page_ + page_offset_;
-      page_offset_ += bytes;
+      // Keep page_offset_ aligned as the CPU natural word size.
+      page_offset_ += (bytes + sizeof(uintptr_t) - 1) & (~sizeof(uintptr_t) + 1);
       if (page_offset_ == page_size_) {
         page_offset_ = 0;
         current_page_ = NULL;


### PR DESCRIPTION
This is can be an issue on ARM, it can cause a hang of `CrashReportTest.MiniDump` test on macOS, that I quite often observe.

I will propose these changes to Chromium.